### PR TITLE
fix: update test expectations for cascade-filtering system

### DIFF
--- a/ClubDoorman.Test/ModerationServiceTests.cs
+++ b/ClubDoorman.Test/ModerationServiceTests.cs
@@ -31,13 +31,15 @@ public class ModerationServiceTests
     {
         // Arrange
         var message = SampleMessages.CreateValidMessage();
+        _factory.ClassifierMock.Setup(x => x.IsSpam(It.IsAny<string>()))
+            .ReturnsAsync((false, -1.5f)); // Уверенный ham (не спам)
 
         // Act
         var result = await _service.CheckMessageAsync(message);
 
         // Assert
         Assert.That(result.Action, Is.EqualTo(ModerationAction.Allow));
-        Assert.That(result.Reason, Is.EqualTo("Сообщение прошло все проверки"));
+        Assert.That(result.Reason, Is.EqualTo("ML уверен что это не спам"));
     }
 
     [Test]
@@ -61,6 +63,8 @@ public class ModerationServiceTests
     {
         // Arrange
         var message = SampleMessages.CreateMimicryMessage();
+        _factory.ClassifierMock.Setup(x => x.IsSpam(It.IsAny<string>()))
+            .ReturnsAsync((false, -1.2f)); // Уверенный ham (не спам)
         // Мимикрия обрабатывается в другом месте, здесь просто проверяем что сообщение проходит
 
         // Act

--- a/ClubDoorman.Test/Services/ModerationServiceTests.cs
+++ b/ClubDoorman.Test/Services/ModerationServiceTests.cs
@@ -31,7 +31,7 @@ public class ModerationServiceTests
         
         _factory.WithClassifierSetup(mock => 
             mock.Setup(x => x.IsSpam(It.IsAny<string>()))
-                .ReturnsAsync((false, 0.2f)));
+                .ReturnsAsync((false, -1.5f))); // Уверенный ham (не спам)
         
         _factory.WithMimicryClassifierSetup(mock => 
             mock.Setup(x => x.AnalyzeMessages(It.IsAny<List<string>>()))
@@ -75,7 +75,7 @@ public class ModerationServiceTests
         
         _factory.WithClassifierSetup(mock => 
             mock.Setup(x => x.IsSpam(It.IsAny<string>()))
-                .ReturnsAsync((false, 0.2f)));
+                .ReturnsAsync((false, -1.5f))); // Уверенный ham (не спам)
         
         _factory.WithMimicryClassifierSetup(mock => 
             mock.Setup(x => x.AnalyzeMessages(It.IsAny<List<string>>()))

--- a/ClubDoorman.Test/Unit/Moderation/ModerationServiceExtendedTests.cs
+++ b/ClubDoorman.Test/Unit/Moderation/ModerationServiceExtendedTests.cs
@@ -325,6 +325,10 @@ public class ModerationServiceExtendedTests
     public async Task CheckMessageAsync_UserWithoutFirstName_HandlesGracefully()
     {
         // Arrange
+        _factory.WithClassifierSetup(mock => 
+            mock.Setup(x => x.IsSpam(It.IsAny<string>()))
+                .ReturnsAsync((false, -1.5f))); // Уверенный ham (не спам)
+        
         var service = _factory.CreateModerationService();
         var message = new Message
         {
@@ -344,6 +348,10 @@ public class ModerationServiceExtendedTests
     public async Task CheckMessageAsync_ChatWithoutId_HandlesGracefully()
     {
         // Arrange
+        _factory.WithClassifierSetup(mock => 
+            mock.Setup(x => x.IsSpam(It.IsAny<string>()))
+                .ReturnsAsync((false, -1.5f))); // Уверенный ham (не спам)
+        
         var service = _factory.CreateModerationService();
         var message = new Message
         {
@@ -363,6 +371,10 @@ public class ModerationServiceExtendedTests
     public async Task CheckMessageAsync_ConcurrentCalls_HandlesCorrectly()
     {
         // Arrange
+        _factory.WithClassifierSetup(mock => 
+            mock.Setup(x => x.IsSpam(It.IsAny<string>()))
+                .ReturnsAsync((false, -1.5f))); // Уверенный ham (не спам)
+        
         var service = _factory.CreateModerationService();
         var message = TestDataFactory.CreateValidMessage();
         var tasks = new List<Task<ModerationResult>>();
@@ -388,6 +400,10 @@ public class ModerationServiceExtendedTests
     public async Task CheckMessageAsync_WithMimicryDetection_ReturnsAllow()
     {
         // Arrange
+        _factory.WithClassifierSetup(mock => 
+            mock.Setup(x => x.IsSpam(It.IsAny<string>()))
+                .ReturnsAsync((false, -1.5f))); // Уверенный ham (не спам)
+        
         _factory.WithMimicryClassifierSetup(mock => 
             mock.Setup(x => x.AnalyzeMessages(It.IsAny<List<string>>()))
                 .Returns(0.9));

--- a/ClubDoorman.Test/Unit/Moderation/ModerationServiceTests.cs
+++ b/ClubDoorman.Test/Unit/Moderation/ModerationServiceTests.cs
@@ -37,6 +37,10 @@ public class ModerationServiceTests
     public async Task CheckMessageAsync_ValidMessage_ReturnsAllow()
     {
         // Arrange
+        _factory.WithClassifierSetup(mock => 
+            mock.Setup(x => x.IsSpam(It.IsAny<string>()))
+                .ReturnsAsync((false, -1.5f))); // Уверенный ham (не спам)
+        
         var service = _factory.CreateModerationService();
         var message = new Message
         {

--- a/ClubDoorman.Test/Unit/Services/ModerationServiceBusinessLogicTests.cs
+++ b/ClubDoorman.Test/Unit/Services/ModerationServiceBusinessLogicTests.cs
@@ -104,6 +104,10 @@ public class ModerationServiceBusinessLogicTests
         // Arrange
         var message = CreateTestMessage(123456L, "Hello");
         
+        _factory.WithClassifierSetup(mock => 
+            mock.Setup(x => x.IsSpam(It.IsAny<string>()))
+                .ReturnsAsync((false, -1.5f))); // Уверенный ham (не спам)
+        
         // Мимикрия проверяется только для подозрительных пользователей
         // и только в AnalyzeMimicryAndMarkSuspicious, не в CheckMessageAsync
         // Поэтому этот тест не корректен - убираем его
@@ -123,7 +127,7 @@ public class ModerationServiceBusinessLogicTests
         
         _factory.WithClassifierSetup(mock => 
             mock.Setup(x => x.IsSpam(It.IsAny<string>()))
-                .ReturnsAsync((false, 0.1f)));
+                .ReturnsAsync((false, -1.5f))); // Уверенный ham (не спам)
         
         _factory.WithMimicryClassifierSetup(mock => 
             mock.Setup(x => x.AnalyzeMessages(It.IsAny<List<string>>()))


### PR DESCRIPTION
## 🔧 Исправления тестов для cascade-filtering системы

### Проблема
После интеграции cascade-filtering системы из апстрима 10 тестов начали падать, ожидая , но получая .

### Причина
Новая cascade логика изменила поведение:
- ML → AI → Manual review
- 'Серая зона' (-0.3 до 0.3) требует AI анализа
- Тесты не были замоканы для ML классификатора

### Исправления
- ✅ Добавлены моки ML классификатора во все падающие тесты
- ✅ Установлены уверенные ham скоры (-1.5f) вместо неопределенных (0.2f)
- ✅ Обновлены ожидания тестов под новую логику

### Измененные файлы
- 
- 
- 
- 
- 

### Результат
- ✅ 592 теста прошли, 0 сбоев (было 10 падающих)
- ✅ Cascade-filtering система работает с правильными тестами
- ✅ E2E тесты отключены из CI

### Технические детали


Теперь все тесты корректно работают с новой cascade-filtering системой!