### PR TITLE
Модерация сообщений от имени каналов

### DIFF
--- a/ClubDoorman.Test/Integration/MessageHandlerBanBasicTests.cs
+++ b/ClubDoorman.Test/Integration/MessageHandlerBanBasicTests.cs
@@ -55,6 +55,10 @@ public class MessageHandlerBanBasicTests
         var violationTrackerMock = new Mock<IViolationTracker>();
         var userBanServiceMock = TK.CreateMockUserBanService();
         
+        // Настраиваем ServiceProvider для возврата IChannelModerationService
+        serviceProviderMock.Setup(x => x.GetService(typeof(IChannelModerationService)))
+            .Returns(new Mock<IChannelModerationService>().Object);
+        
         // Настраиваем базовые моки
         appConfigMock.Setup(x => x.IsChatAllowed(It.IsAny<long>())).Returns(true);
         appConfigMock.Setup(x => x.DisabledChats).Returns(new HashSet<long>());

--- a/ClubDoorman.Test/Integration/MessageHandlerBanExceptionTests.cs
+++ b/ClubDoorman.Test/Integration/MessageHandlerBanExceptionTests.cs
@@ -60,6 +60,10 @@ public class MessageHandlerBanExceptionTests
         var chatLinkFormatterMock = new Mock<IChatLinkFormatter>();
         var violationTrackerMock = new Mock<IViolationTracker>();
         
+        // Настраиваем ServiceProvider для возврата IChannelModerationService
+        serviceProviderMock.Setup(x => x.GetService(typeof(IChannelModerationService)))
+            .Returns(new Mock<IChannelModerationService>().Object);
+        
         // Настраиваем базовые моки
         appConfigMock.Setup(x => x.IsChatAllowed(It.IsAny<long>())).Returns(true);
         appConfigMock.Setup(x => x.DisabledChats).Returns(new HashSet<long>());

--- a/ClubDoorman.Test/Integration/MessageHandlerBanTests.cs
+++ b/ClubDoorman.Test/Integration/MessageHandlerBanTests.cs
@@ -266,18 +266,10 @@ public class MessageHandlerBanTests
         var update = new Update { Message = message };
         await handler.HandleAsync(update, CancellationToken.None);
 
-        // Assert - проверяем legacy поведение (прямые вызовы бота)
-        factory.BotMock.Verify(
-            x => x.BanChatSenderChat(
-                It.IsAny<ChatId>(),
-                It.IsAny<long>(),
-                It.IsAny<CancellationToken>()),
-            Times.Once);
-        
-        factory.BotMock.Verify(
-            x => x.DeleteMessage(
-                It.IsAny<ChatId>(),
-                It.IsAny<int>(),
+        // Assert - проверяем новое поведение через ChannelModerationService
+        factory.ChannelModerationServiceMock.Verify(
+            x => x.HandleChannelMessageAsync(
+                It.IsAny<Message>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -581,18 +573,10 @@ public class MessageHandlerBanTests
         var update = new Update { Message = message };
         await handler.HandleAsync(update, CancellationToken.None);
 
-        // Assert - проверяем legacy поведение (прямые вызовы бота)
-        factory.BotMock.Verify(
-            x => x.BanChatSenderChat(
-                It.IsAny<ChatId>(),
-                It.IsAny<long>(),
-                It.IsAny<CancellationToken>()),
-            Times.Once);
-        
-        factory.BotMock.Verify(
-            x => x.DeleteMessage(
-                It.IsAny<ChatId>(),
-                It.IsAny<int>(),
+        // Assert - проверяем новое поведение через ChannelModerationService
+        factory.ChannelModerationServiceMock.Verify(
+            x => x.HandleChannelMessageAsync(
+                It.IsAny<Message>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }

--- a/ClubDoorman.Test/TestInfrastructure/FakeServicesFactory.cs
+++ b/ClubDoorman.Test/TestInfrastructure/FakeServicesFactory.cs
@@ -145,6 +145,10 @@ public class FakeServicesFactory
         botPermissionsServiceMock.Setup(x => x.IsSilentModeAsync(It.IsAny<long>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
         botPermissionsServiceMock.Setup(x => x.GetBotChatMemberAsync(It.IsAny<long>(), It.IsAny<CancellationToken>())).ReturnsAsync((ChatMember?)null);
         
+        // Настраиваем ServiceProvider для возврата IChannelModerationService
+        serviceProviderMock.Setup(x => x.GetService(typeof(IChannelModerationService)))
+            .Returns(new Mock<IChannelModerationService>().Object);
+        
         var logger = _loggerFactory.CreateLogger<MessageHandler>();
 
         return new MessageHandler(

--- a/ClubDoorman.Test/TestInfrastructure/FakeTelegramClient.cs
+++ b/ClubDoorman.Test/TestInfrastructure/FakeTelegramClient.cs
@@ -515,6 +515,65 @@ public class FakeTelegramClient : ITelegramBotClientWrapper
         return Task.FromResult(chatMember);
     }
 
+    public Task<ChatMember[]> GetChatAdministratorsAsync(ChatId chatId, CancellationToken cancellationToken = default)
+    {
+        if (ShouldThrowException)
+            throw ExceptionToThrow ?? new Exception("Fake exception");
+
+        // Возвращаем фейковых администраторов чата
+        var administrators = new ChatMember[]
+        {
+            new ChatMemberOwner
+            {
+                User = new User { Id = 123, FirstName = "TestOwner", Username = "testowner" },
+                IsAnonymous = false,
+                CustomTitle = "Owner"
+            },
+            new ChatMemberAdministrator
+            {
+                User = new User { Id = 456, FirstName = "TestAdmin", Username = "testadmin" },
+                IsAnonymous = false,
+                CanManageChat = true,
+                CanDeleteMessages = true,
+                CanManageVideoChats = true,
+                CanRestrictMembers = true,
+                CanPromoteMembers = true,
+                CanChangeInfo = true,
+                CanInviteUsers = true,
+                CanPostMessages = false,
+                CanEditMessages = false,
+                CanPinMessages = false,
+                CanPostStories = false,
+                CanEditStories = false,
+                CanDeleteStories = false,
+                CustomTitle = "Admin"
+            }
+        };
+
+        OperationLog.Add($"GetChatAdministratorsAsync: chatId={chatId.Identifier}");
+        return Task.FromResult(administrators);
+    }
+
+    public Task<Chat> GetChatAsync(ChatId chatId, CancellationToken cancellationToken = default)
+    {
+        if (ShouldThrowException)
+            throw ExceptionToThrow ?? new Exception("Fake exception");
+
+        // Возвращаем фейковую информацию о чате
+        var chat = new Chat
+        {
+            Id = chatId.Identifier ?? 0,
+            Type = ChatType.Supergroup,
+            Title = "Test Chat",
+            Username = "testchat",
+            FirstName = null,
+            LastName = null
+        };
+
+        OperationLog.Add($"GetChatAsync: chatId={chatId.Identifier}");
+        return Task.FromResult(chat);
+    }
+
     // Методы для тестирования
     public void Reset()
     {

--- a/ClubDoorman.Test/TestInfrastructure/MessageHandlerTestFactory.cs
+++ b/ClubDoorman.Test/TestInfrastructure/MessageHandlerTestFactory.cs
@@ -72,6 +72,13 @@ public class MessageHandlerTestFactory
 
     public MessageHandler CreateMessageHandler()
     {
+        // Настраиваем ServiceProvider для возврата IChannelModerationService если еще не настроен
+        if (!ServiceProviderMock.Setups.Any(s => s.ToString().Contains("IChannelModerationService")))
+        {
+            ServiceProviderMock.Setup(x => x.GetService(typeof(IChannelModerationService)))
+                .Returns(ChannelModerationServiceMock.Object);
+        }
+        
         return new MessageHandler(
             BotMock.Object,
             ModerationServiceMock.Object,
@@ -96,6 +103,13 @@ public class MessageHandlerTestFactory
     
     public MessageHandler CreateMessageHandlerWithRealUserBanService()
     {
+        // Настраиваем ServiceProvider для возврата IChannelModerationService если еще не настроен
+        if (!ServiceProviderMock.Setups.Any(s => s.ToString().Contains("IChannelModerationService")))
+        {
+            ServiceProviderMock.Setup(x => x.GetService(typeof(IChannelModerationService)))
+                .Returns(ChannelModerationServiceMock.Object);
+        }
+        
         return new MessageHandler(
             BotMock.Object,
             ModerationServiceMock.Object,
@@ -426,6 +440,13 @@ public class MessageHandlerTestFactory
 
     public MessageHandler CreateMessageHandlerWithFake(FakeTelegramClient fakeClient)
     {
+        // Настраиваем ServiceProvider для возврата IChannelModerationService если еще не настроен
+        if (!ServiceProviderMock.Setups.Any(s => s.ToString().Contains("IChannelModerationService")))
+        {
+            ServiceProviderMock.Setup(x => x.GetService(typeof(IChannelModerationService)))
+                .Returns(ChannelModerationServiceMock.Object);
+        }
+        
         // Настраиваем мок для удаления сообщений
         TelegramBotClientWrapperMock.Setup(x => x.DeleteMessage(It.IsAny<ChatId>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .Callback<ChatId, int, CancellationToken>((chatId, messageId, token) =>

--- a/ClubDoorman.Test/TestInfrastructure/MessageHandlerTestFactory.cs
+++ b/ClubDoorman.Test/TestInfrastructure/MessageHandlerTestFactory.cs
@@ -45,6 +45,7 @@ public class MessageHandlerTestFactory
     public Mock<IAppConfig> AppConfigMock { get; } = TK.CreateMockAppConfig();
     public Mock<IViolationTracker> ViolationTrackerMock { get; } = TK.CreateMockViolationTracker();
     public Mock<IUserBanService> UserBanServiceMock { get; } = TK.CreateMockUserBanService();
+    public Mock<IChannelModerationService> ChannelModerationServiceMock { get; } = TK.CreateMock<IChannelModerationService>();
 
     public Mock<IUserCleanupService> UserCleanupServiceMock { get; } = TK.CreateMock<IUserCleanupService>();
     
@@ -304,6 +305,10 @@ public class MessageHandlerTestFactory
                 .Returns(startCommandHandler);
             mock.Setup(x => x.GetService(typeof(SuspiciousCommandHandler)))
                 .Returns(suspiciousCommandHandler);
+            
+            // Настраиваем ServiceProvider для возврата IChannelModerationService
+            mock.Setup(x => x.GetService(typeof(IChannelModerationService)))
+                .Returns(ChannelModerationServiceMock.Object);
         });
         
         return this;

--- a/ClubDoorman.Test/TestKit/Infra/TestKitAutoFixture.cs
+++ b/ClubDoorman.Test/TestKit/Infra/TestKitAutoFixture.cs
@@ -66,6 +66,42 @@ public static class TestKitAutoFixture
         fixture.Customize<IUserManager>(composer => composer
             .FromFactory(() => TK.CreateMockUserManager().Object));
 
+        fixture.Customize<IChannelModerationService>(composer => composer
+            .FromFactory(() => TK.CreateMock<IChannelModerationService>().Object));
+
+        // Отключаем AutoProperties для MessageHandler чтобы избежать проблем с DI
+        fixture.Customize<MessageHandler>(composer => composer
+            .FromFactory(() =>
+            {
+                var bot = TK.CreateMockBotClientWrapper().Object;
+                var moderationService = TK.CreateMockModerationService().Object;
+                var captchaService = TK.CreateMockCaptchaService().Object;
+                var userManager = TK.CreateMockUserManager().Object;
+                var classifier = TK.CreateMockSpamHamClassifier().Object;
+                var badMessageManager = new Mock<IBadMessageManager>().Object;
+                var aiChecks = TK.CreateMockAiChecks().Object;
+                var globalStatsManager = new GlobalStatsManager();
+                var statisticsService = TK.CreateMockStatisticsService().Object;
+                var serviceProvider = new Mock<IServiceProvider>();
+                serviceProvider.Setup(x => x.GetService(typeof(IChannelModerationService)))
+                    .Returns(TK.CreateMock<IChannelModerationService>().Object);
+                var userFlowLogger = new Mock<IUserFlowLogger>().Object;
+                var messageService = TK.CreateMockMessageService().Object;
+                var chatLinkFormatter = new Mock<IChatLinkFormatter>().Object;
+                var botPermissionsService = TK.CreateMockBotPermissionsService().Object;
+                var appConfig = TK.CreateMockAppConfig().Object;
+                var violationTracker = new ViolationTracker(new Mock<ILogger<ViolationTracker>>().Object, appConfig);
+                var logger = new Mock<ILogger<MessageHandler>>().Object;
+                var userBanService = TK.CreateMockUserBanService().Object;
+
+                return new MessageHandler(
+                    bot, moderationService, captchaService, userManager, classifier,
+                    badMessageManager, aiChecks, globalStatsManager, statisticsService,
+                    serviceProvider.Object, userFlowLogger, messageService, chatLinkFormatter,
+                    botPermissionsService, appConfig, violationTracker, logger, userBanService);
+            })
+            .OmitAutoProperties());
+
         return fixture;
     }
 
@@ -283,7 +319,7 @@ public static class TestKitAutoFixture
     /// </summary>
     public static (T sut, IFixture fixture) CreateWithFixture<T>()
     {
-        var fixture = new Fixture().Customize(new AutoMoqCustomization());
+        var fixture = CreateFixture(); // Используем нашу кастомизированную фикстуру
         var sut = fixture.Create<T>();
         return (sut, fixture);
     }

--- a/ClubDoorman.Test/TestKit/TestKit.MessageHandlerBuilder.cs
+++ b/ClubDoorman.Test/TestKit/TestKit.MessageHandlerBuilder.cs
@@ -290,6 +290,13 @@ public class MessageHandlerBuilder
     /// </summary>
     public MessageHandler Build()
     {
+        // Настраиваем ServiceProvider для возврата IChannelModerationService если еще не настроен
+        if (!_serviceProviderMock.Setups.Any(s => s.ToString().Contains("IChannelModerationService")))
+        {
+            _serviceProviderMock.Setup(x => x.GetService(typeof(IChannelModerationService)))
+                .Returns(_channelModerationServiceMock.Object);
+        }
+        
         return new MessageHandler(
             _botMock.Object,
             _moderationServiceMock.Object,

--- a/ClubDoorman.Test/TestKit/TestKit.MessageHandlerBuilder.cs
+++ b/ClubDoorman.Test/TestKit/TestKit.MessageHandlerBuilder.cs
@@ -42,6 +42,7 @@ public class MessageHandlerBuilder
     private readonly Mock<IViolationTracker> _violationTrackerMock = TK.CreateMockViolationTracker();
     private readonly Mock<IUserBanService> _userBanServiceMock = TK.CreateMockUserBanService();
     private readonly Mock<ILogChatService> _logChatServiceMock = TK.CreateMock<ILogChatService>();
+    private readonly Mock<IChannelModerationService> _channelModerationServiceMock = TK.CreateMock<IChannelModerationService>();
     private readonly Mock<ILogger<MessageHandler>> _loggerMock = TK.CreateLoggerMock<MessageHandler>();
     private readonly Mock<ILogger<SuspiciousCommandHandler>> _suspiciousCommandHandlerLoggerMock = TK.CreateLoggerMock<SuspiciousCommandHandler>();
     private readonly Mock<ISuspiciousUsersStorage> _suspiciousUsersStorageMock = TK.CreateMock<ISuspiciousUsersStorage>();
@@ -192,6 +193,10 @@ public class MessageHandlerBuilder
         // Настраиваем IServiceProvider для возврата ILogChatService
         _serviceProviderMock.Setup(x => x.GetService(typeof(ILogChatService)))
             .Returns(_logChatServiceMock.Object);
+        
+        // Настраиваем IServiceProvider для возврата IChannelModerationService
+        _serviceProviderMock.Setup(x => x.GetService(typeof(IChannelModerationService)))
+            .Returns(_channelModerationServiceMock.Object);
         
         return this;
     }

--- a/ClubDoorman.Test/Unit/Handlers/MessageHandlerGoldenMasterTests.cs
+++ b/ClubDoorman.Test/Unit/Handlers/MessageHandlerGoldenMasterTests.cs
@@ -43,6 +43,10 @@ public class MessageHandlerGoldenMasterTests
         // Настраиваем UserManager для HandleBlacklistBan
         _factory.UserManagerMock.Setup(x => x.RemoveApproval(It.IsAny<long>(), It.IsAny<long?>(), It.IsAny<bool>())).Returns(false);
         
+        // Настраиваем ServiceProvider для возврата IChannelModerationService
+        _factory.ServiceProviderMock.Setup(x => x.GetService(typeof(IChannelModerationService)))
+            .Returns(_factory.ChannelModerationServiceMock.Object);
+        
         _messageHandler = _factory.CreateMessageHandlerWithRealUserBanService();
         _userBanService = _factory.CreateRealUserBanService();
     }

--- a/ClubDoorman.Test/Unit/Services/ChannelModerationServiceTests.cs
+++ b/ClubDoorman.Test/Unit/Services/ChannelModerationServiceTests.cs
@@ -46,7 +46,7 @@ public class ChannelModerationServiceTests
             new ChatMemberOwner { User = new User { Id = 123 } }
         };
         
-        _botMock.Setup(x => x.GetChatAdministratorsAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+        _botMock.Setup(x => x.GetChatAdministratorsAsync(It.IsAny<ChatId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(channelAdmins);
 
         // Act
@@ -66,7 +66,7 @@ public class ChannelModerationServiceTests
             new ChatMemberOwner { User = new User { Id = 456 } }
         };
         
-        _botMock.Setup(x => x.GetChatAdministratorsAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+        _botMock.Setup(x => x.GetChatAdministratorsAsync(It.IsAny<ChatId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(channelAdmins);
 
         // Act
@@ -86,9 +86,9 @@ public class ChannelModerationServiceTests
             new ChatMemberOwner { User = new User { Id = 123 } }
         };
         
-        _botMock.Setup(x => x.GetChatAdministratorsAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+        _botMock.Setup(x => x.GetChatAdministratorsAsync(It.IsAny<ChatId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(channelAdmins);
-        _botMock.Setup(x => x.GetChatAsync(It.IsAny<Chat>(), It.IsAny<CancellationToken>()))
+        _botMock.Setup(x => x.GetChatAsync(It.IsAny<ChatId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Chat { Id = 1, Type = ChatType.Supergroup });
 
         // Act
@@ -105,7 +105,7 @@ public class ChannelModerationServiceTests
         var message = CreateTestMessage();
         message.IsAutomaticForward = true;
         
-        _botMock.Setup(x => x.GetChatAsync(It.IsAny<Chat>(), It.IsAny<CancellationToken>()))
+        _botMock.Setup(x => x.GetChatAsync(It.IsAny<ChatId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Chat { Id = 1, Type = ChatType.Supergroup });
 
         // Act
@@ -125,9 +125,9 @@ public class ChannelModerationServiceTests
             new ChatMemberOwner { User = new User { Id = 456 } }
         };
         
-        _botMock.Setup(x => x.GetChatAdministratorsAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+        _botMock.Setup(x => x.GetChatAdministratorsAsync(It.IsAny<ChatId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(channelAdmins);
-        _botMock.Setup(x => x.GetChatAsync(It.IsAny<Chat>(), It.IsAny<CancellationToken>()))
+        _botMock.Setup(x => x.GetChatAsync(It.IsAny<ChatId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Chat { Id = 1, Type = ChatType.Supergroup });
 
         // Act

--- a/ClubDoorman.Test/Unit/Services/ChannelModerationServiceTests.cs
+++ b/ClubDoorman.Test/Unit/Services/ChannelModerationServiceTests.cs
@@ -1,51 +1,150 @@
 using ClubDoorman.Handlers;
+using ClubDoorman.Infrastructure;
 using ClubDoorman.Services;
 using ClubDoorman.Services.BanSystem;
-using ClubDoorman.Test.TestKit;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NUnit.Framework;
 using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
 
 namespace ClubDoorman.Test.Unit.Services;
 
 /// <summary>
 /// Тесты для ChannelModerationService
-/// <tags>unit, services, channel-moderation, proxy</tags>
+/// <tags>channel, moderation, tests</tags>
 /// </summary>
-[TestFixture]
-[Category("unit")]
-[Category("services")]
-[Category("channel-moderation")]
 public class ChannelModerationServiceTests
 {
-    private Mock<IMessageHandler> _messageHandlerMock = null!;
+    private Mock<ITelegramBotClientWrapper> _botMock = null!;
+    private Mock<IModerationService> _moderationServiceMock = null!;
+    private Mock<IUserBanService> _userBanServiceMock = null!;
     private Mock<ILogger<ChannelModerationService>> _loggerMock = null!;
     private ChannelModerationService _service = null!;
 
-    [SetUp]
+        [SetUp]
     public void Setup()
     {
-        _messageHandlerMock = new Mock<IMessageHandler>();
+        _botMock = new Mock<ITelegramBotClientWrapper>();
+        _moderationServiceMock = new Mock<IModerationService>();
+        _userBanServiceMock = new Mock<IUserBanService>();
         _loggerMock = new Mock<ILogger<ChannelModerationService>>();
-        _service = new ChannelModerationService(_messageHandlerMock.Object, _loggerMock.Object);
+
+        _service = new ChannelModerationService(
+            _botMock.Object,
+            _moderationServiceMock.Object,
+            _userBanServiceMock.Object,
+            _loggerMock.Object);
     }
 
-    /// <summary>
-    /// POC: Проверка проксирования вызова HandleChannelMessageAsync
-    /// <tags>poc, proxy, channel-moderation</tags>
-    /// </summary>
     [Test]
-    public async Task HandleChannelMessageAsync_ValidMessage_ProxiesToMessageHandler()
+    public async Task IsChannelOwnerAsync_WhenUserIsOwner_ShouldReturnTrue()
     {
         // Arrange
-        var message = TK.CreateMessage();
-        var cancellationToken = CancellationToken.None;
+        var message = CreateTestMessage();
+        var channelAdmins = new[]
+        {
+            new ChatMemberOwner { User = new User { Id = 123 } }
+        };
+        
+        _botMock.Setup(x => x.GetChatAdministratorsAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(channelAdmins);
 
         // Act
-        await _service.HandleChannelMessageAsync(message, cancellationToken);
+        var result = await _service.IsChannelOwnerAsync(message);
 
         // Assert
-        _messageHandlerMock.Verify(x => x.HandleChannelMessageAsync(message, cancellationToken), Times.Once);
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public async Task IsChannelOwnerAsync_WhenUserIsNotOwner_ShouldReturnFalse()
+    {
+        // Arrange
+        var message = CreateTestMessage();
+        var channelAdmins = new[]
+        {
+            new ChatMemberOwner { User = new User { Id = 456 } }
+        };
+        
+        _botMock.Setup(x => x.GetChatAdministratorsAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(channelAdmins);
+
+        // Act
+        var result = await _service.IsChannelOwnerAsync(message);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public async Task ShouldAllowChannelMessageAsync_WhenUserIsOwner_ShouldReturnTrue()
+    {
+        // Arrange
+        var message = CreateTestMessage();
+        var channelAdmins = new[]
+        {
+            new ChatMemberOwner { User = new User { Id = 123 } }
+        };
+        
+        _botMock.Setup(x => x.GetChatAdministratorsAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(channelAdmins);
+        _botMock.Setup(x => x.GetChatAsync(It.IsAny<Chat>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Chat { Id = 1, Type = ChatType.Supergroup });
+
+        // Act
+        var result = await _service.ShouldAllowChannelMessageAsync(message);
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public async Task ShouldAllowChannelMessageAsync_WhenChannelDiscussion_ShouldReturnTrue()
+    {
+        // Arrange
+        var message = CreateTestMessage();
+        message.IsAutomaticForward = true;
+        
+        _botMock.Setup(x => x.GetChatAsync(It.IsAny<Chat>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Chat { Id = 1, Type = ChatType.Supergroup });
+
+        // Act
+        var result = await _service.ShouldAllowChannelMessageAsync(message);
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public async Task ShouldAllowChannelMessageAsync_WhenUnknownChannel_ShouldReturnFalse()
+    {
+        // Arrange
+        var message = CreateTestMessage();
+        var channelAdmins = new[]
+        {
+            new ChatMemberOwner { User = new User { Id = 456 } }
+        };
+        
+        _botMock.Setup(x => x.GetChatAdministratorsAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(channelAdmins);
+        _botMock.Setup(x => x.GetChatAsync(It.IsAny<Chat>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Chat { Id = 1, Type = ChatType.Supergroup });
+
+        // Act
+        var result = await _service.ShouldAllowChannelMessageAsync(message);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    private static Message CreateTestMessage()
+    {
+        return new Message
+        {
+            From = new User { Id = 123, FirstName = "Test", Username = "testuser" },
+            Chat = new Chat { Id = 1, Title = "Test Chat", Type = ChatType.Supergroup },
+            SenderChat = new Chat { Id = 2, Title = "Test Channel", Type = ChatType.Channel },
+            Text = "Test message"
+        };
     }
 } 

--- a/ClubDoorman/Handlers/MessageHandler.cs
+++ b/ClubDoorman/Handlers/MessageHandler.cs
@@ -41,6 +41,7 @@ public class MessageHandler : IUpdateHandler, IMessageHandler
     private readonly IAppConfig _appConfig;
     private readonly IViolationTracker _violationTracker;
     private readonly IUserBanService _userBanService;
+    private readonly IChannelModerationService _channelModerationService;
 
     // Флаги присоединившихся пользователей (временные)
     private static readonly ConcurrentDictionary<string, byte> _joinedUserFlags = new();
@@ -105,6 +106,7 @@ public class MessageHandler : IUpdateHandler, IMessageHandler
         _violationTracker = violationTracker ?? throw new ArgumentNullException(nameof(violationTracker));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _userBanService = userBanService ?? throw new ArgumentNullException(nameof(userBanService));
+        _channelModerationService = serviceProvider.GetRequiredService<IChannelModerationService>();
     }
 
     /// <summary>
@@ -593,41 +595,8 @@ public class MessageHandler : IUpdateHandler, IMessageHandler
 
     public async Task HandleChannelMessageAsync(Message message, CancellationToken cancellationToken)
     {
-        var chat = message.Chat;
-        var senderChat = message.SenderChat!;
-
-        // Разрешаем сообщения от самого чата
-        if (senderChat.Id == chat.Id)
-            return;
-
-        // Разрешаем в announcement чатах
-        if (ChatSettingsManager.GetChatType(chat.Id) == "announcement")
-            return;
-
-        // Проверяем связанный чат
-        try
-        {
-            var chatFull = await _bot.GetChat(chat, cancellationToken);
-            // Проверяем, является ли это обсуждением канала
-            if (chat.Type == ChatType.Supergroup && message.IsAutomaticForward)
-                return;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Не удалось получить информацию о чате {ChatId}", chat.Id);
-        }
-
-        // Автобан каналов если включен
-        if (Config.ChannelAutoBan)
-        {
-            await _userBanService.AutoBanChannelAsync(message, cancellationToken);
-        }
-        else
-        {
-            // Просто репортим
-            _logger.LogInformation("Сообщение от канала {ChannelTitle} в чате {ChatTitle} - репорт в админ-чат", 
-                senderChat.Title, chat.Title);
-        }
+        _logger.LogDebug("🔍 MessageHandler: Делегируем обработку канала к ChannelModerationService");
+        await _channelModerationService.HandleChannelMessageAsync(message, cancellationToken);
     }
 
     private async Task HandleUserMessageAsync(Message message, bool isSilentMode, CancellationToken cancellationToken)

--- a/ClubDoorman/Handlers/MessageHandler.cs
+++ b/ClubDoorman/Handlers/MessageHandler.cs
@@ -106,7 +106,8 @@ public class MessageHandler : IUpdateHandler, IMessageHandler
         _violationTracker = violationTracker ?? throw new ArgumentNullException(nameof(violationTracker));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _userBanService = userBanService ?? throw new ArgumentNullException(nameof(userBanService));
-        _channelModerationService = serviceProvider.GetRequiredService<IChannelModerationService>();
+        _channelModerationService = serviceProvider.GetService<IChannelModerationService>() 
+            ?? throw new InvalidOperationException("IChannelModerationService is not registered in the DI container");
     }
 
     /// <summary>

--- a/ClubDoorman/Program.cs
+++ b/ClubDoorman/Program.cs
@@ -397,7 +397,16 @@ public class Program
                         provider.GetRequiredService<IUserBanService>());
                 });
                 services.AddSingleton<ICommandProcessingService, CommandProcessingService>();
-                services.AddSingleton<IChannelModerationService, ChannelModerationService>();
+                        services.AddSingleton<IChannelModerationService>(provider =>
+        {
+            var logger = provider.GetRequiredService<ILogger<Program>>();
+            logger.LogDebug("[DI] IChannelModerationService factory called");
+            return new ChannelModerationService(
+                provider.GetRequiredService<ITelegramBotClientWrapper>(),
+                provider.GetRequiredService<IModerationService>(),
+                provider.GetRequiredService<IUserBanService>(),
+                provider.GetRequiredService<ILogger<ChannelModerationService>>());
+        });
                 services.AddSingleton<IUserJoinService, UserJoinService>();
                 services.AddSingleton<INotificationService, NotificationService>();
 

--- a/ClubDoorman/Services/ChannelModerationService.cs
+++ b/ClubDoorman/Services/ChannelModerationService.cs
@@ -1,6 +1,9 @@
-using ClubDoorman.Handlers;
+using ClubDoorman.Infrastructure;
+using ClubDoorman.Models;
+using ClubDoorman.Services.BanSystem;
 using Microsoft.Extensions.Logging;
 using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
 
 namespace ClubDoorman.Services;
 
@@ -10,18 +13,28 @@ namespace ClubDoorman.Services;
 /// </summary>
 public class ChannelModerationService : IChannelModerationService
 {
-    private readonly IMessageHandler _messageHandler;
+    private readonly ITelegramBotClientWrapper _bot;
+    private readonly IModerationService _moderationService;
+    private readonly IUserBanService _userBanService;
     private readonly ILogger<ChannelModerationService> _logger;
 
     /// <summary>
     /// Создает экземпляр ChannelModerationService
     /// <tags>channel, constructor, dependency-injection</tags>
     /// </summary>
-    /// <param name="messageHandler">Обработчик сообщений</param>
+    /// <param name="bot">Клиент Telegram бота</param>
+    /// <param name="moderationService">Сервис модерации</param>
+    /// <param name="userBanService">Сервис управления банами</param>
     /// <param name="logger">Логгер</param>
-    public ChannelModerationService(IMessageHandler messageHandler, ILogger<ChannelModerationService> logger)
+    public ChannelModerationService(
+        ITelegramBotClientWrapper bot,
+        IModerationService moderationService,
+        IUserBanService userBanService,
+        ILogger<ChannelModerationService> logger)
     {
-        _messageHandler = messageHandler ?? throw new ArgumentNullException(nameof(messageHandler));
+        _bot = bot ?? throw new ArgumentNullException(nameof(bot));
+        _moderationService = moderationService ?? throw new ArgumentNullException(nameof(moderationService));
+        _userBanService = userBanService ?? throw new ArgumentNullException(nameof(userBanService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -33,7 +46,242 @@ public class ChannelModerationService : IChannelModerationService
     /// <param name="cancellationToken">Токен отмены</param>
     public async Task HandleChannelMessageAsync(Message message, CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("ChannelModerationService: Проксируем HandleChannelMessageAsync к MessageHandler");
-        await _messageHandler.HandleChannelMessageAsync(message, cancellationToken);
+        var chat = message.Chat;
+        var senderChat = message.SenderChat!;
+
+        _logger.LogDebug("🔍 Обрабатываем сообщение от канала {ChannelTitle} в чате {ChatTitle}", 
+            senderChat.Title, chat.Title);
+
+        // Разрешаем сообщения от самого чата
+        if (senderChat.Id == chat.Id)
+        {
+            _logger.LogDebug("✅ Канал {ChannelTitle} является самим чатом - разрешаем", senderChat.Title);
+            return;
+        }
+
+        // Разрешаем в announcement чатах
+        if (ChatSettingsManager.GetChatType(chat.Id) == "announcement")
+        {
+            _logger.LogDebug("✅ Чат {ChatTitle} является announcement - разрешаем", chat.Title);
+            return;
+        }
+
+        // Проверяем, следует ли разрешить сообщение без модерации
+        if (await ShouldAllowChannelMessageAsync(message, cancellationToken))
+        {
+            _logger.LogDebug("✅ Сообщение от канала {ChannelTitle} разрешено без модерации", senderChat.Title);
+            return;
+        }
+
+        // Автобан каналов если включен
+        if (Config.ChannelAutoBan)
+        {
+            _logger.LogInformation("🚫 Автобан канала {ChannelTitle} включен - баним", senderChat.Title);
+            await _userBanService.AutoBanChannelAsync(message, cancellationToken);
+        }
+        else
+        {
+            // Проверяем, одобрен ли пользователь (если есть информация о пользователе)
+            if (message.From != null && _moderationService.IsUserApproved(message.From.Id, chat.Id))
+            {
+                _logger.LogDebug("✅ Пользователь {UserId} уже одобрен в чате {ChatId}, пропускаем модерацию канала {ChannelTitle}", 
+                    message.From.Id, chat.Id, senderChat.Title);
+                return;
+            }
+            
+            // Модерация содержимого для неизвестных каналов
+            _logger.LogInformation("🔍 Модерация содержимого сообщения от канала {ChannelTitle} в чате {ChatTitle}", 
+                senderChat.Title, chat.Title);
+            
+            await ModerateChannelMessageContentAsync(message, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Проверяет, является ли отправитель владельцем канала
+    /// <tags>channel, owner, validation</tags>
+    /// </summary>
+    /// <param name="message">Сообщение от канала</param>
+    /// <param name="cancellationToken">Токен отмены</param>
+    /// <returns>true, если отправитель является владельцем канала</returns>
+    public async Task<bool> IsChannelOwnerAsync(Message message, CancellationToken cancellationToken = default)
+    {
+        if (message.From == null)
+        {
+            _logger.LogDebug("❌ Сообщение без отправителя - не может быть владельцем канала");
+            return false;
+        }
+
+        try
+        {
+            var senderChat = message.SenderChat!;
+            var channelAdmins = await _bot.GetChatAdministratorsAsync(senderChat.Id, cancellationToken);
+            
+            var isOwner = channelAdmins.Any(admin => 
+                admin.User.Id == message.From.Id && 
+                admin.Status == ChatMemberStatus.Creator);
+            
+            if (isOwner)
+            {
+                _logger.LogDebug("✅ Пользователь {UserId} является владельцем канала {ChannelTitle}", 
+                    message.From.Id, senderChat.Title);
+            }
+            else
+            {
+                _logger.LogDebug("❌ Пользователь {UserId} не является владельцем канала {ChannelTitle}", 
+                    message.From.Id, senderChat.Title);
+            }
+            
+            return isOwner;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "⚠️ Не удалось проверить владельца канала {ChannelId} - разрешаем сообщение", message.SenderChat?.Id);
+            return false; // Если не можем проверить - проверяем дальше
+        }
+    }
+
+    /// <summary>
+    /// Проверяет, является ли чат обсуждением данного канала
+    /// <tags>channel, discussion, linked</tags>
+    /// </summary>
+    /// <param name="message">Сообщение от канала</param>
+    /// <param name="cancellationToken">Токен отмены</param>
+    /// <returns>true, если чат является обсуждением канала</returns>
+    public async Task<bool> IsChannelDiscussionAsync(Message message, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var chat = message.Chat;
+            var senderChat = message.SenderChat!;
+            
+            // Проверяем, является ли это обсуждением канала
+            if (chat.Type == ChatType.Supergroup && message.IsAutomaticForward)
+            {
+                _logger.LogDebug("✅ Чат {ChatTitle} является обсуждением канала {ChannelTitle}", 
+                    chat.Title, senderChat.Title);
+                return true;
+            }
+            
+            // Проверяем связанный чат через ChatFullInfo
+            try
+            {
+                var chatFullInfo = await _bot.GetChatFullInfo(chat.Id, cancellationToken);
+                if (chatFullInfo.LinkedChatId == senderChat.Id)
+                {
+                    _logger.LogDebug("✅ Чат {ChatTitle} связан с каналом {ChannelTitle}", 
+                        chat.Title, senderChat.Title);
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Не удалось получить ChatFullInfo для чата {ChatId}", chat.Id);
+            }
+            
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "⚠️ Не удалось проверить связь чата {ChatId} с каналом {ChannelId}", 
+                message.Chat.Id, message.SenderChat?.Id);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Проверяет, следует ли разрешить сообщение от канала без модерации
+    /// <tags>channel, moderation, allow</tags>
+    /// </summary>
+    /// <param name="message">Сообщение от канала</param>
+    /// <param name="cancellationToken">Токен отмены</param>
+    /// <returns>true, если сообщение следует разрешить без модерации</returns>
+    public async Task<bool> ShouldAllowChannelMessageAsync(Message message, CancellationToken cancellationToken = default)
+    {
+        // 1. Проверяем, является ли чат обсуждением канала
+        if (await IsChannelDiscussionAsync(message, cancellationToken))
+        {
+            return true;
+        }
+        
+        // 2. Проверяем, является ли отправитель владельцем канала
+        if (await IsChannelOwnerAsync(message, cancellationToken))
+        {
+            return true;
+        }
+        
+        return false;
+    }
+
+    /// <summary>
+    /// Модерирует содержимое сообщения от канала
+    /// <tags>channel, moderation, content</tags>
+    /// </summary>
+    /// <param name="message">Сообщение от канала</param>
+    /// <param name="cancellationToken">Токен отмены</param>
+    private async Task ModerateChannelMessageContentAsync(Message message, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var senderChat = message.SenderChat!;
+            var chat = message.Chat;
+            
+            _logger.LogInformation("🔍 Модерируем содержимое сообщения от канала {ChannelTitle} в чате {ChatTitle}", 
+                senderChat.Title, chat.Title);
+            
+            // Проверяем содержимое сообщения через ModerationService
+            var moderationResult = await _moderationService.CheckMessageAsync(message);
+            
+            switch (moderationResult.Action)
+            {
+                case ModerationAction.Allow:
+                    _logger.LogDebug("✅ Содержимое сообщения от канала {ChannelTitle} разрешено: {Reason}", 
+                        senderChat.Title, moderationResult.Reason);
+                    
+                    // Засчитываем хорошее сообщение для одобрения пользователя
+                    if (message.From != null)
+                    {
+                        var allowedMessageText = message.Text ?? message.Caption ?? "";
+                        
+                        // Проверяем AI детект для подозрительных пользователей
+                        var aiDetectBlocked = await _moderationService.CheckAiDetectAndNotifyAdminsAsync(message.From, chat, message);
+                        
+                        // Засчитываем хорошее сообщение только если пользователь не был заблокирован AI детектом
+                        if (!aiDetectBlocked)
+                        {
+                            await _moderationService.IncrementGoodMessageCountAsync(message.From, chat, allowedMessageText);
+                        }
+                    }
+                    break;
+                
+                case ModerationAction.Delete:
+                    _logger.LogInformation("🗑️ Удаляем сообщение от канала {ChannelTitle}: {Reason}", 
+                        senderChat.Title, moderationResult.Reason);
+                    await _bot.DeleteMessage(chat.Id, message.MessageId, cancellationToken);
+                    break;
+                
+                case ModerationAction.Report:
+                    _logger.LogInformation("📋 Отправляем сообщение от канала {ChannelTitle} в админ-чат: {Reason}", 
+                        senderChat.Title, moderationResult.Reason);
+                    // Здесь можно добавить отправку в админ-чат
+                    break;
+                
+                case ModerationAction.Ban:
+                    _logger.LogWarning("🚫 Баним канал {ChannelTitle} за содержимое: {Reason}", 
+                        senderChat.Title, moderationResult.Reason);
+                    await _userBanService.AutoBanChannelAsync(message, cancellationToken);
+                    break;
+                
+                default:
+                    _logger.LogInformation("❓ Неизвестное действие модерации для канала {ChannelTitle}: {Action}", 
+                        senderChat.Title, moderationResult.Action);
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "❌ Ошибка при модерации содержимого сообщения от канала {ChannelTitle}", 
+                message.SenderChat?.Title);
+        }
     }
 } 

--- a/ClubDoorman/Services/IChannelModerationService.cs
+++ b/ClubDoorman/Services/IChannelModerationService.cs
@@ -15,4 +15,31 @@ public interface IChannelModerationService
     /// <param name="message">Сообщение от канала</param>
     /// <param name="cancellationToken">Токен отмены</param>
     Task HandleChannelMessageAsync(Message message, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Проверяет, является ли отправитель владельцем канала
+    /// <tags>channel, owner, validation</tags>
+    /// </summary>
+    /// <param name="message">Сообщение от канала</param>
+    /// <param name="cancellationToken">Токен отмены</param>
+    /// <returns>true, если отправитель является владельцем канала</returns>
+    Task<bool> IsChannelOwnerAsync(Message message, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Проверяет, является ли чат обсуждением данного канала
+    /// <tags>channel, discussion, linked</tags>
+    /// </summary>
+    /// <param name="message">Сообщение от канала</param>
+    /// <param name="cancellationToken">Токен отмены</param>
+    /// <returns>true, если чат является обсуждением канала</returns>
+    Task<bool> IsChannelDiscussionAsync(Message message, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Проверяет, следует ли разрешить сообщение от канала без модерации
+    /// <tags>channel, moderation, allow</tags>
+    /// </summary>
+    /// <param name="message">Сообщение от канала</param>
+    /// <param name="cancellationToken">Токен отмены</param>
+    /// <returns>true, если сообщение следует разрешить без модерации</returns>
+    Task<bool> ShouldAllowChannelMessageAsync(Message message, CancellationToken cancellationToken = default);
 } 

--- a/ClubDoorman/Services/ITelegramBotClientWrapper.cs
+++ b/ClubDoorman/Services/ITelegramBotClientWrapper.cs
@@ -173,4 +173,14 @@ public interface ITelegramBotClientWrapper
     /// Получает информацию о члене чата
     /// </summary>
     Task<ChatMember> GetChatMember(ChatId chatId, long userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Получает список администраторов чата
+    /// </summary>
+    Task<ChatMember[]> GetChatAdministratorsAsync(ChatId chatId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Получает информацию о чате (альтернативный метод)
+    /// </summary>
+    Task<Chat> GetChatAsync(ChatId chatId, CancellationToken cancellationToken = default);
 } 

--- a/ClubDoorman/Services/TelegramBotClientWrapper.cs
+++ b/ClubDoorman/Services/TelegramBotClientWrapper.cs
@@ -300,4 +300,20 @@ public class TelegramBotClientWrapper : ITelegramBotClientWrapper
     {
         return await _bot.GetChatMember(chatId, userId, cancellationToken);
     }
+
+    /// <summary>
+    /// Получает список администраторов чата
+    /// </summary>
+    public async Task<ChatMember[]> GetChatAdministratorsAsync(ChatId chatId, CancellationToken cancellationToken = default)
+    {
+        return await _bot.GetChatAdministrators(chatId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Получает информацию о чате (альтернативный метод)
+    /// </summary>
+    public async Task<Chat> GetChatAsync(ChatId chatId, CancellationToken cancellationToken = default)
+    {
+        return await _bot.GetChat(chatId, cancellationToken);
+    }
 } 


### PR DESCRIPTION
Теперь сообщения от каналов модерируются как и остальные. При этом, сообщения от именного канала местного чата, проверки пропускает.

- Добавлена проверка IsUserApproved в ChannelModerationService перед модерацией содержимого
- Пропуск модерации для одобренных пользователей, постящих от каналов, для улучшения производительности
- Предотвращение ненужных вызовов ML модели и обработки фильтров для одобренных пользователей
- Сохранение существующего flow одобрения без дублирования

