### PR TITLE
fix: remove duplicate AdminOpsFeature registration to stop command ha…

### DIFF
--- a/ClubDoorman/Infrastructure/ServiceCollectionExtensions.cs
+++ b/ClubDoorman/Infrastructure/ServiceCollectionExtensions.cs
@@ -140,9 +140,11 @@ public static class ServiceCollectionExtensions
         services.AddMessagingServices();
         services.AddTextProcessingServices();
         services.AddCaptchaServices();
-        services.AddHandlersServices();
-        services.AddCommandsServices();
-        services.AddAdminOpsFeature();
+    services.AddHandlersServices();
+    // ВНИМАНИЕ: AddCommandsServices уже вызывает AddAdminOpsFeature внутри (обратная совместимость).
+    // Ранее здесь вызывались И AddCommandsServices(), И AddAdminOpsFeature(), что приводило к двойной
+    // регистрации ICommandHandler и предупреждениям CommandRouter про дубли команд.
+    services.AddCommandsServices(); // один вызов достаточно
 
         // Регистрация Worker как HostedService
         services.AddHostedService<Worker>(provider =>


### PR DESCRIPTION
Сделано:

Удалён повторный вызов → исключены двойные регистрации [ICommandHandler](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Сборка и тесты прошли (только прежние предупреждения).


При следующем запуске предупреждения о дубликатах исчезнут.