### PR TITLE
test: add architecture dependency ratchets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ venv/
 /html/
 /latex/
 .opencode/
+.opencode-work/
 
 # Local AI/code graph build state
 .refactor-mcp/

--- a/ClubDoorman.Test/Architecture/DependencyRulesTests.cs
+++ b/ClubDoorman.Test/Architecture/DependencyRulesTests.cs
@@ -1,9 +1,5 @@
 using ClubDoorman.Features.Moderation;
-using ClubDoorman.Services.Core.Configuration;
 using ClubDoorman.Services.Handlers.Pipeline;
-using ClubDoorman.Services.Handlers.Pipeline.Steps;
-using ClubDoorman.Services.SuspiciousUsers;
-using ClubDoorman.Services.UserManagement;
 using NetArchTest.Rules;
 using NUnit.Framework;
 
@@ -12,69 +8,84 @@ namespace ClubDoorman.Test.Architecture;
 [TestFixture]
 public class DependencyRulesTests
 {
-    private static readonly Type[] ConcreteStorageOrConfigurationTypes =
-    [
-        typeof(AppConfig),
-        typeof(ConfigurationHelper),
-        typeof(AiOptions),
-        typeof(AutoBanOptions),
-        typeof(ChatAccessOptions),
-        typeof(ChatFilteringOptions),
-        typeof(CoreOptions),
-        typeof(FeatureToggleOptions),
-        typeof(TestHarnessOptions),
-        typeof(ViolationThresholdOptions),
-        typeof(ApprovedUsersStorage),
-        typeof(UserIndex),
-        typeof(JoinedUserFlags),
-        typeof(SuspiciousUsersStorage)
-    ];
-
-    // Existing steps access Telegram message data through MessageContext and are exempt as whole types.
-    private static readonly Type[] LegacyTelegramStepTypes =
-    [
-        typeof(AiProfileAnalysisStep),
-        typeof(AlreadyApprovedStep),
-        typeof(BanlistCheckStep),
-        typeof(BaseModerationStep),
-        typeof(CaptchaPendingStep),
-        typeof(ChannelMessageStep),
-        typeof(ClubMemberSkipStep),
-        typeof(CommandStep),
-        typeof(FinalModerationActionStep),
-        typeof(FirstMessageLogStep),
-        typeof(NewMembersStep),
-        typeof(PrivateSkipStep),
-        typeof(LeftMemberCleanupStep),
-        typeof(SystemOrBotMessageStep)
-    ];
-
     [Test]
-    public void PipelineSteps_DoNotDependOnConcreteStorageOrConfiguration()
+    public void PipelineSteps_InStepsNamespace_ImplementIMessageStep()
     {
-        var result = Types.InAssembly(typeof(IMessageStep).Assembly)
-            .That()
-            .ImplementInterface(typeof(IMessageStep))
-            .ShouldNot()
-            .HaveDependencyOnAny(FullNamesOf(ConcreteStorageOrConfigurationTypes))
-            .GetResult();
+        var steps = PipelineStepDependencyInspector.GetPipelineStepTypes();
+        Assert.That(steps, Is.Not.Empty, "Expected concrete classes under Pipeline.Steps");
 
-        AssertRulePasses(result, "Pipeline steps must depend on storage and configuration abstractions only");
+        var missing = steps
+            .Where(t => !typeof(IMessageStep).IsAssignableFrom(t))
+            .Select(t => t.FullName)
+            .ToList();
+
+        Assert.That(missing, Is.Empty,
+            "Classes in Pipeline.Steps must implement IMessageStep (including via base class). Missing: "
+            + string.Join(", ", missing));
     }
 
     [Test]
-    public void PipelineSteps_ExceptDocumentedLegacyTypes_DoNotDependOnTelegramSdk()
+    public void PipelineSteps_ConstructorDependencies_MustBeAbstractions()
     {
-        var result = Types.InAssembly(typeof(IMessageStep).Assembly)
-            .That()
-            .ImplementInterface(typeof(IMessageStep))
-            .And()
-            .DoNotHaveName(LegacyTelegramStepTypes.Select(type => type.Name).ToArray())
-            .ShouldNot()
-            .HaveDependencyOn("Telegram.Bot")
-            .GetResult();
+        // Real boundary: steps receive DI collaborators through constructors.
+        // Concrete config/storage/options types must not be constructor parameters.
+        // (Type-graph HaveDependencyOn denylists miss new concrete types until listed by hand.)
+        var violations = PipelineStepDependencyInspector.GetPipelineStepTypes()
+            .SelectMany(PipelineStepDependencyInspector.GetForbiddenConstructorParameters)
+            .ToList();
 
-        AssertRulePasses(result, "Pipeline steps must not depend on the Telegram SDK");
+        Assert.That(violations, Is.Empty,
+            "Pipeline steps must take constructor abstractions only. Violations:\n"
+            + string.Join("\n", violations));
+    }
+
+    [Test]
+    public void PipelineSteps_DirectTelegramTypeRefs_StayWithinBaseline()
+    {
+        // NetArchTest HaveDependencyOn("Telegram.Bot") is transitive and true for every step
+        // that touches MessageContext. We freeze *direct* Telegram.* type refs per FullName so
+        // new SDK surface on an existing step fails the gate.
+        var actual = PipelineStepDependencyInspector.GetDirectTelegramTypeRefs();
+        var baseline = PipelineStepDependencyInspector.AllowedTelegramTypeBaseline;
+        var failures = new List<string>();
+
+        foreach (var (fullName, refs) in actual)
+        {
+            var allowed = baseline.TryGetValue(fullName, out var listed)
+                ? listed
+                : Array.Empty<string>();
+            var allowedSet = new HashSet<string>(allowed, StringComparer.Ordinal);
+
+            var outsideTypes = refs
+                .Where(r => !r.StartsWith("Telegram.Bot.Types", StringComparison.Ordinal))
+                .ToList();
+            if (outsideTypes.Count > 0)
+            {
+                failures.Add(
+                    $"{fullName}: Telegram client/SDK types are forbidden (use ITelegramBotClientWrapper). "
+                    + string.Join(", ", outsideTypes));
+            }
+
+            var extras = refs.Where(r => !allowedSet.Contains(r)).ToList();
+            if (extras.Count > 0)
+            {
+                failures.Add(
+                    $"{fullName}: new Telegram type refs beyond baseline: {string.Join(", ", extras)}. "
+                    + "Update AllowedTelegramTypeBaseline deliberately if this is intended.");
+            }
+            // Baseline shrink (removed usage) is allowed; only expansions fail the gate.
+        }
+
+        // Baseline entries must still exist as step types (typos / renames break the gate).
+        foreach (var key in baseline.Keys)
+        {
+            if (!actual.ContainsKey(key))
+                failures.Add($"Baseline lists unknown step FullName: {key}");
+        }
+
+        Assert.That(failures, Is.Empty,
+            "Pipeline steps Telegram surface must stay within the frozen baseline.\n"
+            + string.Join("\n", failures));
     }
 
     [Test]
@@ -89,9 +100,6 @@ public class DependencyRulesTests
 
         AssertRulePasses(result, "The moderation feature must not depend on handlers");
     }
-
-    private static string[] FullNamesOf(IEnumerable<Type> types) =>
-        types.Select(type => type.FullName!).ToArray();
 
     private static void AssertRulePasses(TestResult result, string rule)
     {

--- a/ClubDoorman.Test/Architecture/DependencyRulesTests.cs
+++ b/ClubDoorman.Test/Architecture/DependencyRulesTests.cs
@@ -1,0 +1,101 @@
+using ClubDoorman.Features.Moderation;
+using ClubDoorman.Services.Core.Configuration;
+using ClubDoorman.Services.Handlers.Pipeline;
+using ClubDoorman.Services.Handlers.Pipeline.Steps;
+using ClubDoorman.Services.SuspiciousUsers;
+using ClubDoorman.Services.UserManagement;
+using NetArchTest.Rules;
+using NUnit.Framework;
+
+namespace ClubDoorman.Test.Architecture;
+
+[TestFixture]
+public class DependencyRulesTests
+{
+    private static readonly Type[] ConcreteStorageOrConfigurationTypes =
+    [
+        typeof(AppConfig),
+        typeof(ConfigurationHelper),
+        typeof(AiOptions),
+        typeof(AutoBanOptions),
+        typeof(ChatAccessOptions),
+        typeof(ChatFilteringOptions),
+        typeof(CoreOptions),
+        typeof(FeatureToggleOptions),
+        typeof(TestHarnessOptions),
+        typeof(ViolationThresholdOptions),
+        typeof(ApprovedUsersStorage),
+        typeof(UserIndex),
+        typeof(JoinedUserFlags),
+        typeof(SuspiciousUsersStorage)
+    ];
+
+    // Existing steps access Telegram message data through MessageContext and are exempt as whole types.
+    private static readonly Type[] LegacyTelegramStepTypes =
+    [
+        typeof(AiProfileAnalysisStep),
+        typeof(AlreadyApprovedStep),
+        typeof(BanlistCheckStep),
+        typeof(BaseModerationStep),
+        typeof(CaptchaPendingStep),
+        typeof(ChannelMessageStep),
+        typeof(ClubMemberSkipStep),
+        typeof(CommandStep),
+        typeof(FinalModerationActionStep),
+        typeof(FirstMessageLogStep),
+        typeof(NewMembersStep),
+        typeof(PrivateSkipStep),
+        typeof(LeftMemberCleanupStep),
+        typeof(SystemOrBotMessageStep)
+    ];
+
+    [Test]
+    public void PipelineSteps_DoNotDependOnConcreteStorageOrConfiguration()
+    {
+        var result = Types.InAssembly(typeof(IMessageStep).Assembly)
+            .That()
+            .ImplementInterface(typeof(IMessageStep))
+            .ShouldNot()
+            .HaveDependencyOnAny(FullNamesOf(ConcreteStorageOrConfigurationTypes))
+            .GetResult();
+
+        AssertRulePasses(result, "Pipeline steps must depend on storage and configuration abstractions only");
+    }
+
+    [Test]
+    public void PipelineSteps_ExceptDocumentedLegacyTypes_DoNotDependOnTelegramSdk()
+    {
+        var result = Types.InAssembly(typeof(IMessageStep).Assembly)
+            .That()
+            .ImplementInterface(typeof(IMessageStep))
+            .And()
+            .DoNotHaveName(LegacyTelegramStepTypes.Select(type => type.Name).ToArray())
+            .ShouldNot()
+            .HaveDependencyOn("Telegram.Bot")
+            .GetResult();
+
+        AssertRulePasses(result, "Pipeline steps must not depend on the Telegram SDK");
+    }
+
+    [Test]
+    public void ModerationFeature_DoesNotDependOnHandlers()
+    {
+        var result = Types.InAssembly(typeof(ModerationFeature).Assembly)
+            .That()
+            .ResideInNamespace("ClubDoorman.Features.Moderation")
+            .ShouldNot()
+            .HaveDependencyOn("ClubDoorman.Services.Handlers")
+            .GetResult();
+
+        AssertRulePasses(result, "The moderation feature must not depend on handlers");
+    }
+
+    private static string[] FullNamesOf(IEnumerable<Type> types) =>
+        types.Select(type => type.FullName!).ToArray();
+
+    private static void AssertRulePasses(TestResult result, string rule)
+    {
+        var failures = string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>());
+        Assert.That(result.IsSuccessful, Is.True, $"{rule}. Violations: {failures}");
+    }
+}

--- a/ClubDoorman.Test/Architecture/DependencyRulesTests.cs
+++ b/ClubDoorman.Test/Architecture/DependencyRulesTests.cs
@@ -9,33 +9,33 @@ namespace ClubDoorman.Test.Architecture;
 public class DependencyRulesTests
 {
     [Test]
-    public void PipelineSteps_InStepsNamespace_ImplementIMessageStep()
+    public void IMessageStep_ConcreteImplementations_ResideInPipelineStepsNamespace()
     {
-        var steps = PipelineStepDependencyInspector.GetPipelineStepTypes();
-        Assert.That(steps, Is.Not.Empty, "Expected concrete classes under Pipeline.Steps");
+        var steps = PipelineStepDependencyInspector.GetConcreteMessageSteps();
+        Assert.That(steps, Is.Not.Empty, "Expected concrete IMessageStep implementations");
 
-        var missing = steps
-            .Where(t => !typeof(IMessageStep).IsAssignableFrom(t))
+        var outside = steps
+            .Where(t => !PipelineStepDependencyInspector.IsInStepsNamespace(t.Namespace))
             .Select(t => t.FullName)
             .ToList();
 
-        Assert.That(missing, Is.Empty,
-            "Classes in Pipeline.Steps must implement IMessageStep (including via base class). Missing: "
-            + string.Join(", ", missing));
+        Assert.That(outside, Is.Empty,
+            "Concrete IMessageStep implementations must reside in "
+            + $"{PipelineStepDependencyInspector.StepsNamespace} or a child namespace. Outside: "
+            + string.Join(", ", outside));
     }
 
     [Test]
-    public void PipelineSteps_ConstructorDependencies_MustBeAbstractions()
+    public void PipelineSteps_DoNotTakeStatefulConcreteInfrastructureInConstructors()
     {
-        // Real boundary: steps receive DI collaborators through constructors.
-        // Concrete config/storage/options types must not be constructor parameters.
-        // (Type-graph HaveDependencyOn denylists miss new concrete types until listed by hand.)
-        var violations = PipelineStepDependencyInspector.GetPipelineStepTypes()
+        // Boundary: steps must not DI-inject concrete storage/cache/config/infra services.
+        // Interfaces, abstracts, value types, and ordinary DTOs/value objects remain allowed.
+        var violations = PipelineStepDependencyInspector.GetConcreteMessageSteps()
             .SelectMany(PipelineStepDependencyInspector.GetForbiddenConstructorParameters)
             .ToList();
 
         Assert.That(violations, Is.Empty,
-            "Pipeline steps must take constructor abstractions only. Violations:\n"
+            "Pipeline steps must not take stateful concrete infrastructure in constructors. Violations:\n"
             + string.Join("\n", violations));
     }
 

--- a/ClubDoorman.Test/Architecture/DependencyRulesTests.cs
+++ b/ClubDoorman.Test/Architecture/DependencyRulesTests.cs
@@ -43,8 +43,9 @@ public class DependencyRulesTests
     public void PipelineSteps_DirectTelegramTypeRefs_StayWithinBaseline()
     {
         // NetArchTest HaveDependencyOn("Telegram.Bot") is transitive and true for every step
-        // that touches MessageContext. We freeze *direct* Telegram.* type refs per FullName so
-        // new SDK surface on an existing step fails the gate.
+        // that touches MessageContext. We freeze the *exact current* set of direct Telegram.*
+        // type refs per step FullName (including nested async state machines) so both expansion
+        // and shrink require an intentional baseline update.
         var actual = PipelineStepDependencyInspector.GetDirectTelegramTypeRefs();
         var baseline = PipelineStepDependencyInspector.AllowedTelegramTypeBaseline;
         var failures = new List<string>();
@@ -73,7 +74,14 @@ public class DependencyRulesTests
                     $"{fullName}: new Telegram type refs beyond baseline: {string.Join(", ", extras)}. "
                     + "Update AllowedTelegramTypeBaseline deliberately if this is intended.");
             }
-            // Baseline shrink (removed usage) is allowed; only expansions fail the gate.
+
+            var stale = allowedSet.Where(a => !refs.Contains(a)).ToList();
+            if (stale.Count > 0)
+            {
+                failures.Add(
+                    $"{fullName}: baseline still allows unused Telegram type refs: {string.Join(", ", stale)}. "
+                    + "Shrink AllowedTelegramTypeBaseline deliberately.");
+            }
         }
 
         // Baseline entries must still exist as step types (typos / renames break the gate).
@@ -84,7 +92,7 @@ public class DependencyRulesTests
         }
 
         Assert.That(failures, Is.Empty,
-            "Pipeline steps Telegram surface must stay within the frozen baseline.\n"
+            "Pipeline steps Telegram surface must match the frozen current baseline.\n"
             + string.Join("\n", failures));
     }
 

--- a/ClubDoorman.Test/Architecture/PipelineStepDependencyInspector.cs
+++ b/ClubDoorman.Test/Architecture/PipelineStepDependencyInspector.cs
@@ -6,45 +6,14 @@ namespace ClubDoorman.Test.Architecture;
 
 /// <summary>
 /// Locates pipeline step types and inspects their direct Telegram type references.
-/// Uses Mono.Cecil so base-class implementors of <see cref="IMessageStep"/> are not missed.
+/// Nested types (async state machines) are folded into the outer step's ref set.
 /// </summary>
 internal static class PipelineStepDependencyInspector
 {
     public const string StepsNamespace = "ClubDoorman.Services.Handlers.Pipeline.Steps";
 
-    /// <summary>
-    /// Frozen direct Telegram.* type refs per step FullName.
-    /// Steps absent from this map must not introduce any Telegram type references.
-    /// Expand deliberately when a legacy step needs more Types access; never wholesale-exempt a type.
-    /// </summary>
-    public static readonly IReadOnlyDictionary<string, string[]> AllowedTelegramTypeBaseline =
-        new Dictionary<string, string[]>(StringComparer.Ordinal)
-        {
-            ["ClubDoorman.Services.Handlers.Pipeline.Steps.AlreadyApprovedStep"] =
-            [
-                "Telegram.Bot.Types.Chat",
-                "Telegram.Bot.Types.Message",
-                "Telegram.Bot.Types.User"
-            ],
-            ["ClubDoorman.Services.Handlers.Pipeline.Steps.FirstMessageLogStep"] =
-            [
-                "Telegram.Bot.Types.Chat",
-                "Telegram.Bot.Types.Message",
-                "Telegram.Bot.Types.User"
-            ],
-            ["ClubDoorman.Services.Handlers.Pipeline.Steps.PrivateSkipStep"] =
-            [
-                "Telegram.Bot.Types.Chat",
-                "Telegram.Bot.Types.Enums.ChatType",
-                "Telegram.Bot.Types.Message"
-            ],
-            ["ClubDoorman.Services.Handlers.Pipeline.Steps.SystemOrBotMessageStep"] =
-            [
-                "Telegram.Bot.Types.Chat",
-                "Telegram.Bot.Types.Message",
-                "Telegram.Bot.Types.User"
-            ]
-        };
+    public static IReadOnlyDictionary<string, string[]> AllowedTelegramTypeBaseline =>
+        PipelineStepTelegramBaseline.Allowed;
 
     public static IReadOnlyList<Type> GetPipelineStepTypes()
     {
@@ -54,7 +23,7 @@ internal static class PipelineStepDependencyInspector
                 t is { IsClass: true, IsAbstract: false, IsNested: false } &&
                 t.Namespace is not null &&
                 t.Namespace.StartsWith(StepsNamespace, StringComparison.Ordinal) &&
-                !t.Name.Contains('<', StringComparison.Ordinal)) // skip async state machines
+                !t.Name.Contains('<', StringComparison.Ordinal))
             .OrderBy(t => t.FullName, StringComparer.Ordinal)
             .ToList();
     }
@@ -80,7 +49,8 @@ internal static class PipelineStepDependencyInspector
 
     public static IEnumerable<string> GetForbiddenConstructorParameters(Type stepType)
     {
-        foreach (var ctor in stepType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        // DI collaborators come through public constructors.
+        foreach (var ctor in stepType.GetConstructors(BindingFlags.Instance | BindingFlags.Public))
         {
             foreach (var parameter in ctor.GetParameters())
             {
@@ -100,7 +70,6 @@ internal static class PipelineStepDependencyInspector
         if (type.IsInterface || type.IsAbstract)
             return true;
 
-        // Framework / BCL value plumbing only — no ClubDoorman concrete infra.
         if (type.IsPrimitive || type.IsEnum || type == typeof(string) || type == typeof(decimal))
             return true;
 
@@ -115,7 +84,12 @@ internal static class PipelineStepDependencyInspector
     private static SortedSet<string> CollectTelegramRefs(TypeDefinition type)
     {
         var set = new SortedSet<string>(StringComparer.Ordinal);
+        CollectTelegramRefs(type, set);
+        return set;
+    }
 
+    private static void CollectTelegramRefs(TypeDefinition type, SortedSet<string> set)
+    {
         void Add(TypeReference? tr)
         {
             if (tr is null)
@@ -177,6 +151,8 @@ internal static class PipelineStepDependencyInspector
             }
         }
 
-        return set;
+        // Async ExecuteAsync bodies live in nested state machines (<ExecuteAsync>d__*).
+        foreach (var nestedType in type.NestedTypes)
+            CollectTelegramRefs(nestedType, set);
     }
 }

--- a/ClubDoorman.Test/Architecture/PipelineStepDependencyInspector.cs
+++ b/ClubDoorman.Test/Architecture/PipelineStepDependencyInspector.cs
@@ -5,40 +5,68 @@ using Mono.Cecil;
 namespace ClubDoorman.Test.Architecture;
 
 /// <summary>
-/// Locates pipeline step types and inspects their direct Telegram type references.
-/// Nested types (async state machines) are folded into the outer step's ref set.
+/// Discovers concrete <see cref="IMessageStep"/> types and inspects constructor / Telegram deps.
+/// Nested types (async state machines) are folded into the outer step's Telegram ref set.
 /// </summary>
 internal static class PipelineStepDependencyInspector
 {
     public const string StepsNamespace = "ClubDoorman.Services.Handlers.Pipeline.Steps";
 
+    /// <summary>
+    /// Known infrastructure / storage / mutable-config namespaces.
+    /// Concrete constructor parameters from these are forbidden for pipeline steps.
+    /// </summary>
+    private static readonly string[] ForbiddenConcreteNamespaces =
+    [
+        "ClubDoorman.Services.Core.Configuration",
+        "ClubDoorman.Services.UserManagement",
+        "ClubDoorman.Services.SuspiciousUsers",
+        "ClubDoorman.Infrastructure",
+        "Microsoft.Extensions.Caching.Memory",
+        "Microsoft.Extensions.Caching.Distributed",
+        "System.Runtime.Caching"
+    ];
+
+    private static readonly HashSet<string> ForbiddenConcreteTypeFullNames =
+        new(StringComparer.Ordinal)
+        {
+            "Microsoft.Extensions.Caching.Memory.MemoryCache",
+            "System.Runtime.Caching.MemoryCache"
+        };
+
     public static IReadOnlyDictionary<string, string[]> AllowedTelegramTypeBaseline =>
         PipelineStepTelegramBaseline.Allowed;
 
-    public static IReadOnlyList<Type> GetPipelineStepTypes()
+    public static bool IsInStepsNamespace(string? ns) =>
+        ns == StepsNamespace ||
+        (ns is not null && ns.StartsWith(StepsNamespace + ".", StringComparison.Ordinal));
+
+    /// <summary>
+    /// All concrete IMessageStep implementors in the production assembly (including via base class).
+    /// </summary>
+    public static IReadOnlyList<Type> GetConcreteMessageSteps()
     {
         return typeof(IMessageStep).Assembly
             .GetTypes()
             .Where(t =>
-                t is { IsClass: true, IsAbstract: false, IsNested: false } &&
-                t.Namespace is not null &&
-                t.Namespace.StartsWith(StepsNamespace, StringComparison.Ordinal) &&
-                !t.Name.Contains('<', StringComparison.Ordinal))
+                t is { IsClass: true, IsAbstract: false } &&
+                typeof(IMessageStep).IsAssignableFrom(t))
             .OrderBy(t => t.FullName, StringComparer.Ordinal)
             .ToList();
     }
 
     public static IReadOnlyDictionary<string, SortedSet<string>> GetDirectTelegramTypeRefs()
     {
+        var stepFullNames = GetConcreteMessageSteps()
+            .Select(t => t.FullName!)
+            .ToHashSet(StringComparer.Ordinal);
+
         var assemblyPath = typeof(IMessageStep).Assembly.Location;
         using var module = ModuleDefinition.ReadModule(assemblyPath);
         var result = new Dictionary<string, SortedSet<string>>(StringComparer.Ordinal);
 
         foreach (var type in module.Types
-                     .Where(t =>
-                         t is { IsClass: true, IsNested: false } &&
-                         t.Namespace is not null &&
-                         t.Namespace.StartsWith(StepsNamespace, StringComparison.Ordinal))
+                     .Where(t => t is { IsClass: true, IsNested: false } && stepFullNames.Contains(t.FullName))
                      .OrderBy(t => t.FullName, StringComparer.Ordinal))
         {
             result[type.FullName] = CollectTelegramRefs(type);
@@ -49,34 +77,66 @@ internal static class PipelineStepDependencyInspector
 
     public static IEnumerable<string> GetForbiddenConstructorParameters(Type stepType)
     {
-        // DI collaborators come through public constructors.
         foreach (var ctor in stepType.GetConstructors(BindingFlags.Instance | BindingFlags.Public))
         {
             foreach (var parameter in ctor.GetParameters())
             {
-                var parameterType = parameter.ParameterType;
-                if (IsAllowedConstructorDependency(parameterType))
+                if (!IsForbiddenConstructorDependency(parameter.ParameterType))
                     continue;
 
-                yield return $"{stepType.FullName} ctor param '{parameter.Name}': {parameterType.FullName}";
+                yield return $"{stepType.FullName} ctor param '{parameter.Name}': {parameter.ParameterType.FullName}";
             }
         }
     }
 
-    private static bool IsAllowedConstructorDependency(Type type)
+    /// <summary>
+    /// Forbidden: concrete stateful app/infra services, storage, cache, mutable configuration.
+    /// Allowed: interfaces, abstracts, value types, string, immutable/framework value objects, DTOs.
+    /// </summary>
+    private static bool IsForbiddenConstructorDependency(Type type)
     {
         type = Nullable.GetUnderlyingType(type) ?? type;
 
         if (type.IsInterface || type.IsAbstract)
-            return true;
+            return false;
 
         if (type.IsPrimitive || type.IsEnum || type == typeof(string) || type == typeof(decimal))
+            return false;
+
+        if (type.IsGenericType)
+        {
+            var definition = type.GetGenericTypeDefinition();
+            if (definition.IsInterface || definition.IsAbstract)
+                return false;
+        }
+
+        var fullName = type.FullName ?? type.Name;
+        if (ForbiddenConcreteTypeFullNames.Contains(fullName))
             return true;
 
-        if (type.Namespace is not null &&
-            (type.Namespace.StartsWith("System", StringComparison.Ordinal) ||
-             type.Namespace.StartsWith("Microsoft.Extensions", StringComparison.Ordinal)))
+        var ns = type.Namespace ?? string.Empty;
+        foreach (var forbiddenNs in ForbiddenConcreteNamespaces)
+        {
+            if (ns == forbiddenNs || ns.StartsWith(forbiddenNs + ".", StringComparison.Ordinal))
+                return true;
+        }
+
+        // Infrastructure-shaped ClubDoorman concretes outside the listed namespaces.
+        if (ns.StartsWith("ClubDoorman", StringComparison.Ordinal) &&
+            (type.Name.EndsWith("Storage", StringComparison.Ordinal) ||
+             type.Name.EndsWith("Options", StringComparison.Ordinal) ||
+             type.Name.EndsWith("Cache", StringComparison.Ordinal) ||
+             type.Name.EndsWith("Index", StringComparison.Ordinal)))
+        {
             return true;
+        }
+
+        // Telegram Bot client/API types (message DTOs under Types are allowed).
+        if (ns.StartsWith("Telegram.Bot", StringComparison.Ordinal) &&
+            !ns.StartsWith("Telegram.Bot.Types", StringComparison.Ordinal))
+        {
+            return true;
+        }
 
         return false;
     }

--- a/ClubDoorman.Test/Architecture/PipelineStepDependencyInspector.cs
+++ b/ClubDoorman.Test/Architecture/PipelineStepDependencyInspector.cs
@@ -1,0 +1,182 @@
+using System.Reflection;
+using ClubDoorman.Services.Handlers.Pipeline;
+using Mono.Cecil;
+
+namespace ClubDoorman.Test.Architecture;
+
+/// <summary>
+/// Locates pipeline step types and inspects their direct Telegram type references.
+/// Uses Mono.Cecil so base-class implementors of <see cref="IMessageStep"/> are not missed.
+/// </summary>
+internal static class PipelineStepDependencyInspector
+{
+    public const string StepsNamespace = "ClubDoorman.Services.Handlers.Pipeline.Steps";
+
+    /// <summary>
+    /// Frozen direct Telegram.* type refs per step FullName.
+    /// Steps absent from this map must not introduce any Telegram type references.
+    /// Expand deliberately when a legacy step needs more Types access; never wholesale-exempt a type.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, string[]> AllowedTelegramTypeBaseline =
+        new Dictionary<string, string[]>(StringComparer.Ordinal)
+        {
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.AlreadyApprovedStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.FirstMessageLogStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.PrivateSkipStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Enums.ChatType",
+                "Telegram.Bot.Types.Message"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.SystemOrBotMessageStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ]
+        };
+
+    public static IReadOnlyList<Type> GetPipelineStepTypes()
+    {
+        return typeof(IMessageStep).Assembly
+            .GetTypes()
+            .Where(t =>
+                t is { IsClass: true, IsAbstract: false, IsNested: false } &&
+                t.Namespace is not null &&
+                t.Namespace.StartsWith(StepsNamespace, StringComparison.Ordinal) &&
+                !t.Name.Contains('<', StringComparison.Ordinal)) // skip async state machines
+            .OrderBy(t => t.FullName, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    public static IReadOnlyDictionary<string, SortedSet<string>> GetDirectTelegramTypeRefs()
+    {
+        var assemblyPath = typeof(IMessageStep).Assembly.Location;
+        using var module = ModuleDefinition.ReadModule(assemblyPath);
+        var result = new Dictionary<string, SortedSet<string>>(StringComparer.Ordinal);
+
+        foreach (var type in module.Types
+                     .Where(t =>
+                         t is { IsClass: true, IsNested: false } &&
+                         t.Namespace is not null &&
+                         t.Namespace.StartsWith(StepsNamespace, StringComparison.Ordinal))
+                     .OrderBy(t => t.FullName, StringComparer.Ordinal))
+        {
+            result[type.FullName] = CollectTelegramRefs(type);
+        }
+
+        return result;
+    }
+
+    public static IEnumerable<string> GetForbiddenConstructorParameters(Type stepType)
+    {
+        foreach (var ctor in stepType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            foreach (var parameter in ctor.GetParameters())
+            {
+                var parameterType = parameter.ParameterType;
+                if (IsAllowedConstructorDependency(parameterType))
+                    continue;
+
+                yield return $"{stepType.FullName} ctor param '{parameter.Name}': {parameterType.FullName}";
+            }
+        }
+    }
+
+    private static bool IsAllowedConstructorDependency(Type type)
+    {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (type.IsInterface || type.IsAbstract)
+            return true;
+
+        // Framework / BCL value plumbing only — no ClubDoorman concrete infra.
+        if (type.IsPrimitive || type.IsEnum || type == typeof(string) || type == typeof(decimal))
+            return true;
+
+        if (type.Namespace is not null &&
+            (type.Namespace.StartsWith("System", StringComparison.Ordinal) ||
+             type.Namespace.StartsWith("Microsoft.Extensions", StringComparison.Ordinal)))
+            return true;
+
+        return false;
+    }
+
+    private static SortedSet<string> CollectTelegramRefs(TypeDefinition type)
+    {
+        var set = new SortedSet<string>(StringComparer.Ordinal);
+
+        void Add(TypeReference? tr)
+        {
+            if (tr is null)
+                return;
+
+            switch (tr)
+            {
+                case GenericInstanceType gi:
+                    Add(gi.ElementType);
+                    foreach (var arg in gi.GenericArguments)
+                        Add(arg);
+                    return;
+                case ArrayType or ByReferenceType or PointerType:
+                    Add(tr.GetElementType());
+                    return;
+            }
+
+            var name = tr.FullName;
+            if (name.StartsWith("Telegram.", StringComparison.Ordinal))
+                set.Add(name);
+        }
+
+        foreach (var field in type.Fields)
+            Add(field.FieldType);
+
+        foreach (var property in type.Properties)
+            Add(property.PropertyType);
+
+        foreach (var method in type.Methods)
+        {
+            Add(method.ReturnType);
+            foreach (var parameter in method.Parameters)
+                Add(parameter.ParameterType);
+
+            if (!method.HasBody)
+                continue;
+
+            foreach (var variable in method.Body.Variables)
+                Add(variable.VariableType);
+
+            foreach (var instruction in method.Body.Instructions)
+            {
+                switch (instruction.Operand)
+                {
+                    case MethodReference methodRef:
+                        Add(methodRef.DeclaringType);
+                        Add(methodRef.ReturnType);
+                        foreach (var parameter in methodRef.Parameters)
+                            Add(parameter.ParameterType);
+                        break;
+                    case FieldReference fieldRef:
+                        Add(fieldRef.DeclaringType);
+                        Add(fieldRef.FieldType);
+                        break;
+                    case TypeReference typeRef:
+                        Add(typeRef);
+                        break;
+                }
+            }
+        }
+
+        return set;
+    }
+}

--- a/ClubDoorman.Test/Architecture/PipelineStepTelegramBaseline.cs
+++ b/ClubDoorman.Test/Architecture/PipelineStepTelegramBaseline.cs
@@ -1,0 +1,96 @@
+namespace ClubDoorman.Test.Architecture;
+
+/// <summary>
+/// Exact current direct Telegram.* type refs per pipeline step FullName.
+/// Nested async state-machine refs are included in the step's set by the inspector.
+/// Update deliberately on both expansion and shrink.
+/// </summary>
+internal static class PipelineStepTelegramBaseline
+{
+    public static readonly IReadOnlyDictionary<string, string[]> Allowed =
+        new Dictionary<string, string[]>(StringComparer.Ordinal)
+        {
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.AiProfileAnalysisStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.AlreadyApprovedStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.BanlistCheckStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.BaseModerationStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.CaptchaPendingStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.ChatId",
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.ChannelMessageStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Message"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.ClubMemberSkipStep"] =
+            [
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.CommandStep"] =
+            [
+                "Telegram.Bot.Types.Message"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.FinalModerationActionStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.FirstMessageLogStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.LeftMemberCleanupStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.ChatId",
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.NewMembersStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.PrivateSkipStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Enums.ChatType",
+                "Telegram.Bot.Types.Message"
+            ],
+            ["ClubDoorman.Services.Handlers.Pipeline.Steps.SystemOrBotMessageStep"] =
+            [
+                "Telegram.Bot.Types.Chat",
+                "Telegram.Bot.Types.Message",
+                "Telegram.Bot.Types.User"
+            ]
+        };
+}

--- a/ClubDoorman.Test/ClubDoorman.Test.csproj
+++ b/ClubDoorman.Test/ClubDoorman.Test.csproj
@@ -27,6 +27,7 @@
         <PackageReference Include="FluentAssertions" Version="6.12.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
   <PackageReference Include="NUnit" Version="4.4.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="Scrutor" Version="4.2.2" />

--- a/ClubDoorman.Test/ClubDoorman.Test.csproj
+++ b/ClubDoorman.Test/ClubDoorman.Test.csproj
@@ -27,8 +27,9 @@
         <PackageReference Include="FluentAssertions" Version="6.12.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="Mono.Cecil" Version="0.11.3" />
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
-  <PackageReference Include="NUnit" Version="4.4.0" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="Scrutor" Version="4.2.2" />
         <PackageReference Include="SpecFlow" Version="3.9.74" />


### PR DESCRIPTION
## Summary

Adds focused architecture tests that act as ratchets around the message pipeline without freezing its internal design.

- requires concrete `IMessageStep` implementations to reside under `Pipeline.Steps`
- prevents pipeline steps from constructor-injecting concrete stateful storage, cache, configuration, and infrastructure dependencies
- freezes the current direct `Telegram.*` type surface per pipeline step, detecting both expansion and stale baseline entries
- prevents `Features.Moderation` from depending on handlers

The Telegram inspection includes nested async state-machine types and uses exact per-step baselines.

## Verification

```text
dotnet test --filter FullyQualifiedName~DependencyRulesTests
4 passed
```

GitHub CI passed, including the full test suite.